### PR TITLE
feat: handling in web the sending transceiver from rust sft

### DIFF
--- a/wasm/src/avs_pc.ts
+++ b/wasm/src/avs_pc.ts
@@ -1027,7 +1027,7 @@ function update_tracks(pc: PeerConnection, stream: MediaStream): Promise<void> {
             if (track.kind === 'video' && pc.conv_type !== CONV_TYPE_ONEONONE) {
                 const transceivers = rtc.getTransceivers();
                 for (const trans of transceivers) {
-                    if (trans.mid === 'video' && !!trans.sender) {
+                    if ((trans.mid === 'video' || trans.mid === '1') && !!trans.sender)  {
                         pc_log(LOG_LEVEL_INFO, `update_tracks: adjust`)
                         const {params, layerFound} = getEncodingParameter(trans.sender, pc.vstate === PC_VIDEO_STATE_SCREENSHARE)
 


### PR DESCRIPTION
Add case for sft rust sending transceiver 

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
