### PR TITLE
WPB-23494: Revert packet stats into cumulative values

### DIFF
--- a/src/stats/stats.c
+++ b/src/stats/stats.c
@@ -229,46 +229,40 @@ static int read_packet_stats_and_jitter(struct avs_stats *stats, struct stats_ob
 
 	/*
 	  Calculation of packet and loss statistics
-	  1. save old stats into report
-	      stats->last_packets -->  stats->report.packets
-	  2. read new stast from json
-	      0                   -->  stats->last
-	      webrtc json -->  stats->last_packets + stats->report.jitter
-	  3. update report with the interval difference
-	      stats->report = stats->last_packets - stats->report.packets
-	  4. convert loss into percentage
-	      calcualte percentage for stats->report.packets.loss
+	  1. read json stats into report
+	      webrtc json -> stats.report
+	  2. calculate interval percentage for packet loss into tmp variables
+	      loss_tx = calculate_loss_percentage(...)
+	      loss_rx = calculate_loss_percentage(...)
+	  3. save current packet cumulatives into last
+	  4. update report.packet.lost with percentage loss
+	      report-packets-loss = { loss_tx, loss_rx}
 	*/
 
-	// 1. save old stats into report
-	stats->report.packets = stats->last_packets;
-
-	// 2. read new stast from json
-	memset(&stats->last_packets, 0, sizeof(stats->last_packets));
-
+	// 1. read json stats into report
 	LIST_FOREACH(&stats_obj->inbound_rtp, le) {
 		struct stats_inbound_rtp* data = (struct stats_inbound_rtp*)le->data;
 
 		if (data->kind == STATS_KIND_AUDIO) {
-			stats->last_packets.audio.rx += data->packets_received;
+			stats->report.packets.audio.rx += data->packets_received;
 			stats->report.jitter.audio.rx = max(stats->report.jitter.audio.rx, (1000.0 * data->jitter));
 		}
 		else if (data->kind == STATS_KIND_VIDEO) {
-			stats->last_packets.video.rx += data->packets_received;
+			stats->report.packets.video.rx += data->packets_received;
 			stats->report.jitter.video.rx = max(stats->report.jitter.video.rx, (1000.0 * data->jitter));
 		}
 
-		stats->last_packets.lost.rx += data->packets_lost;
+		stats->report.packets.lost.rx += data->packets_lost;
 	}
 
 	LIST_FOREACH(&stats_obj->outbound_rtp, le) {
 		struct stats_outbound_rtp* data = (struct stats_outbound_rtp*)le->data;
 
 		if (data->kind == STATS_KIND_AUDIO) {
-			stats->last_packets.audio.tx += data->packets_sent;
+			stats->report.packets.audio.tx += data->packets_sent;
 		}
 		else if (data->kind == STATS_KIND_VIDEO) {
-			stats->last_packets.video.tx += data->packets_sent;
+			stats->report.packets.video.tx += data->packets_sent;
 		}
 	}
 
@@ -282,25 +276,26 @@ static int read_packet_stats_and_jitter(struct avs_stats *stats, struct stats_ob
 			stats->report.jitter.video.tx = max(stats->report.jitter.video.tx, (1000 * data->jitter));
 		}
 
-		stats->last_packets.lost.tx += data->packets_lost;
+		stats->report.packets.lost.tx += data->packets_lost;
 	}
 
-	// 3. update report with the interval difference 
-	stats->report.packets.audio.tx = stats->last_packets.audio.tx - stats->report.packets.audio.tx;
-	stats->report.packets.audio.rx = stats->last_packets.audio.rx - stats->report.packets.audio.rx;
-	stats->report.packets.video.tx = stats->last_packets.video.tx - stats->report.packets.video.tx;
-	stats->report.packets.video.rx = stats->last_packets.video.rx - stats->report.packets.video.rx;
-	stats->report.packets.lost.tx = stats->last_packets.lost.tx - stats->report.packets.lost.tx;
-	stats->report.packets.lost.rx = stats->last_packets.lost.rx - stats->report.packets.lost.rx;
+	// 2. calculate interval percentage for packet loss into tmp variables
+	uint32_t loss_tx = calculate_loss_percentage(
+		(stats->report.packets.audio.tx - stats->last_packets.audio.tx +
+		stats->report.packets.video.tx - stats->last_packets.video.tx),
+		stats->report.packets.lost.tx - stats->last_packets.lost.tx);
 
-	// 4. convert loss into percentage
-	stats->report.packets.lost.tx = calculate_loss_percentage(
-		stats->report.packets.audio.tx + stats->report.packets.video.tx,
-		stats->report.packets.lost.tx);
+	uint32_t loss_rx = calculate_loss_percentage(
+		(stats->report.packets.audio.rx - stats->last_packets.audio.rx +
+		stats->report.packets.video.rx - stats->last_packets.video.rx),
+		stats->report.packets.lost.rx - stats->last_packets.lost.rx);
 
-	stats->report.packets.lost.rx = calculate_loss_percentage(
-		stats->report.packets.audio.rx + stats->report.packets.video.rx,
-		stats->report.packets.lost.rx);
+	// 3. save current packet cumulatives into last
+	stats->last_packets = stats->report.packets;
+
+	// 4. update report.packet.lost with calculated percentages
+	stats->report.packets.lost.tx = loss_tx;
+	stats->report.packets.lost.rx = loss_rx;
 
 	return 0;
 }

--- a/test/test_stats.cpp
+++ b/test/test_stats.cpp
@@ -207,6 +207,39 @@ TEST_F(StatsBase, some_packet_stats)
 	EXPECT_EQ(sr.packets, expected_packets);
 }
 
+TEST_F(StatsBase, audio_should_be_cumulative)
+{
+	// An incoming audio streams with 20 packets and 2 packet loss
+	auto audio_rtp = new RTCInboundRtpStreamStats("someRtpId", Timestamp::Zero());
+	audio_rtp->kind = "audio";
+	audio_rtp->packets_received = 20;
+	audio_rtp->packets_lost = 2;
+	report->AddStats(std::unique_ptr<RTCStats>(audio_rtp));
+
+	stats_update(stats, report->ToJson().c_str());
+	stats_get_report(stats, &sr);
+
+	// 20 packets 10% loss
+	EXPECT_EQ(sr.packets.audio.rx, 20);
+	EXPECT_EQ(sr.packets.lost.rx, 10);
+
+
+	// An incoming audio streams with double packets and half packet loss
+	auto new_audio_rtp = new RTCInboundRtpStreamStats("someRtpId", Timestamp::Seconds(10));
+	new_audio_rtp->kind = "audio";
+	new_audio_rtp->packets_received = 20 + 20;
+	new_audio_rtp->packets_lost = 2 + 1;
+	auto new_report = RTCStatsReport::Create(Timestamp::Seconds(10));
+	new_report->AddStats(std::unique_ptr<RTCStats>(new_audio_rtp));
+
+	stats_update(stats, new_report->ToJson().c_str());
+	stats_get_report(stats, &sr);
+
+	// 40 packets 5% loss
+	EXPECT_EQ(sr.packets.audio.rx, 40);
+	EXPECT_EQ(sr.packets.lost.rx, 5);
+}
+
 // ---------------------------------------- Test Audio Level ------------------------------------
 
 TEST_F(StatsBase, audio_level)


### PR DESCRIPTION
Changing stats.packets.audio and stats.packets.video into interval difference broke the sectest. Fix the test by reverting these two back into cumulative.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

_Briefly describe the issue you have solved or implemented with this pull request. If the PR contains multiple issues, use a bullet list._

### Causes (Optional)

_Briefly describe the causes behind the issues. This could be helpful to understand the adopted solutions behind some nasty bugs or complex issues._

### Solutions

_Briefly describe the solutions you have implemented for the issues explained above._

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
