### PR TITLE
Fixes [WPB-24091] Video before answer

### DIFF
--- a/src/ecall/ecall.c
+++ b/src/ecall/ecall.c
@@ -2708,11 +2708,17 @@ int ecall_set_video_send_state(struct ecall *ecall, enum icall_vstate vstate)
 	}
 
 	enum econn_state conn_current_state = econn_current_state(ecall->econn);
-	if (ecall->conv_type == ICALL_CONV_TYPE_ONEONONE && (ecall->update || conn_current_state == ECONN_UPDATE_RECV)) {
-		info("ecall(%p): set_video_send_state: postpone video update state %s, because of glare\n", ecall, icall_vstate_name(ecall->vstate));
-		ecall->update_glare = true;
-		ecall->glare_vstate = vstate;
-		return 0;
+	if (ecall->conv_type == ICALL_CONV_TYPE_ONEONONE) {
+		if (conn_current_state == ECONN_PENDING_OUTGOING ||
+		    conn_current_state == ECONN_PENDING_INCOMING ||
+		    conn_current_state == ECONN_UPDATE_RECV ||
+		    ecall->update) {
+			info("ecall(%p): set_video_send_state: postpone video update state %s, because of glare\n",
+			     ecall, icall_vstate_name(ecall->vstate));
+			ecall->update_glare = true;
+			ecall->glare_vstate = vstate;
+			return 0;
+		}
 	}
 
 


### PR DESCRIPTION
This PR fixes WPB-24091 a problem when video is enabled in a 1:1 call before the other end has answered.
