### PR TITLE
 feat: enhance quality calculation (WPB-24323)

### DIFF
--- a/src/ccall/ccall.c
+++ b/src/ccall/ccall.c
@@ -532,7 +532,10 @@ static void ccall_reconnect(struct ccall *ccall,
 
 	if (notify) {
 
-		struct stats_report stats = { 0 };
+		struct stats_report stats = {
+			.packets.lost.rx = ICALL_RECONNECTING,
+			.packets.lost.tx = ICALL_RECONNECTING,
+		};
 
 		ICALL_CALL_CB(ccall->icall, qualityh,
 			      &ccall->icall, 

--- a/src/egcall/egcall.c
+++ b/src/egcall/egcall.c
@@ -1029,7 +1029,10 @@ static void noconn_handler(void *arg)
 {
 	struct egcall *egcall = arg;
 
-	struct stats_report stats = { 0 };
+	struct stats_report stats = {
+		.packets.lost.rx = ICALL_NETWORK_PROBLEM,
+		.packets.lost.tx = ICALL_NETWORK_PROBLEM,
+	};
 
 	ICALL_CALL_CB(egcall->icall, qualityh,
 		      &egcall->icall,

--- a/src/wcall/wcall.c
+++ b/src/wcall/wcall.c
@@ -18,6 +18,7 @@
 
 #include <pthread.h>
 #include <unistd.h>
+#include <math.h>
 
 #include <re/re.h>
 #include <avs.h>
@@ -1621,6 +1622,42 @@ static void destructor(void *arg)
 	info("wcall(%p): dtor -- done\n", wcall);
 }
 
+static int normalize_to_levels(int num, int low_threshold, int high_threshold) {
+	if (num < low_threshold) {
+		return 1;
+	}
+	else if (num > high_threshold) {
+		return 3;
+	}
+	else {
+		return 2;
+	}
+}
+
+// Quality level thresholds
+const int RTT_LOW = 50;
+const int RTT_HIGH = 150;
+const int JITTER_LOW = 10;
+const int JITTER_HIGH = 50;
+const int PACKET_LOSS_LOW = 5;
+const int PACKET_LOSS_HIGH = 10;
+
+static int normalize_quality(const struct stats_report* stats) {
+	// Stats are 3 step normalized wrt corresponding thresholds
+	const int rtt = normalize_to_levels(stats->rtt, RTT_LOW, RTT_HIGH);
+	const int jitter_tx = normalize_to_levels((stats->jitter.audio.tx + stats->jitter.video.tx) / 2, JITTER_LOW, JITTER_HIGH);
+	const int jitter_rx = normalize_to_levels((stats->jitter.audio.rx + stats->jitter.video.rx) / 2, JITTER_LOW, JITTER_HIGH);
+	const int packet_loss_tx = normalize_to_levels(stats->packets.lost.tx, PACKET_LOSS_LOW, PACKET_LOSS_HIGH);
+	const int packet_loss_rx = normalize_to_levels(stats->packets.lost.rx, PACKET_LOSS_LOW, PACKET_LOSS_HIGH);
+
+	// provide higher importance to upstream stats
+	float jitter = 0.7 * jitter_tx + 0.3 * jitter_rx;
+	float packet_loss = 0.7 * packet_loss_tx + 0.3 * packet_loss_rx;
+
+	// provide packet loss and jitter a bit more importance than latency
+	return round(0.35 * jitter + 0.35 * packet_loss + 0.3 * rtt);
+}
+
 static void icall_quality_handler(struct icall *icall,
 				  const char *userid,
 				  const char *clientid,
@@ -1644,16 +1681,24 @@ static void icall_quality_handler(struct icall *icall,
 	if (!inst->quality.netqh)
 		return;
 
+	// ICALL_NETWORK_PROBLEM and ICALL_RECONNECTING states are
+	// propagated through packet loss stats.
+	// Reset them back if needed to stay inside [0.100] interval.
 	if (stats.packets.lost.tx == ICALL_NETWORK_PROBLEM
-	    && stats.packets.lost.rx == ICALL_NETWORK_PROBLEM)
+		&& stats.packets.lost.rx == ICALL_NETWORK_PROBLEM) {
+		stats.packets.lost.tx = 0;
+		stats.packets.lost.rx = 0;
 		quality = WCALL_QUALITY_NETWORK_PROBLEM;
+	}
 	else if (stats.packets.lost.tx == ICALL_RECONNECTING
-	    && stats.packets.lost.rx == ICALL_RECONNECTING)
+		&& stats.packets.lost.rx == ICALL_RECONNECTING) {
+		stats.packets.lost.tx = 0;
+		stats.packets.lost.rx = 0;
 		quality = WCALL_QUALITY_RECONNECTING;
-	else if (stats.rtt > 800 || stats.packets.lost.tx > 20 || stats.packets.lost.rx > 20)
-		quality = WCALL_QUALITY_POOR;
-	else if (stats.rtt > 400 || stats.packets.lost.tx > 5 || stats.packets.lost.rx > 5)
-		quality = WCALL_QUALITY_MEDIUM;
+	}
+	else {
+		quality = normalize_quality(&stats);
+	}
 
 	now = tmr_jiffies();
 

--- a/src/wcall/wcall.c
+++ b/src/wcall/wcall.c
@@ -1624,13 +1624,13 @@ static void destructor(void *arg)
 
 static int normalize_to_levels(int num, int low_threshold, int high_threshold) {
 	if (num < low_threshold) {
-		return 1;
+		return WCALL_QUALITY_NORMAL;
 	}
 	else if (num > high_threshold) {
-		return 3;
+		return WCALL_QUALITY_POOR;
 	}
 	else {
-		return 2;
+		return WCALL_QUALITY_MEDIUM;
 	}
 }
 
@@ -1642,6 +1642,15 @@ const int JITTER_HIGH = 50;
 const int PACKET_LOSS_LOW = 5;
 const int PACKET_LOSS_HIGH = 10;
 
+// Stream direction weights
+const float UPSTREAM_WEIGHT = 0.7;
+const float DOWNSTREM_WEIGHT = 0.3;
+
+// Overall quality weights
+const float JITTER_WEIGHT = 0.35;
+const float PACKET_LOSS_WEIGHT = 0.35;
+const float RTT_WEIGHT = 0.3;
+
 static int normalize_quality(const struct stats_report* stats) {
 	// Stats are 3 step normalized wrt corresponding thresholds
 	const int rtt = normalize_to_levels(stats->rtt, RTT_LOW, RTT_HIGH);
@@ -1651,11 +1660,11 @@ static int normalize_quality(const struct stats_report* stats) {
 	const int packet_loss_rx = normalize_to_levels(stats->packets.lost.rx, PACKET_LOSS_LOW, PACKET_LOSS_HIGH);
 
 	// provide higher importance to upstream stats
-	float jitter = 0.7 * jitter_tx + 0.3 * jitter_rx;
-	float packet_loss = 0.7 * packet_loss_tx + 0.3 * packet_loss_rx;
+	float jitter = UPSTREAM_WEIGHT * jitter_tx + DOWNSTREM_WEIGHT * jitter_rx;
+	float packet_loss = UPSTREAM_WEIGHT * packet_loss_tx + DOWNSTREM_WEIGHT * packet_loss_rx;
 
 	// provide packet loss and jitter a bit more importance than latency
-	return round(0.35 * jitter + 0.35 * packet_loss + 0.3 * rtt);
+	return round(JITTER_WEIGHT * jitter + PACKET_LOSS_WEIGHT * packet_loss + RTT_WEIGHT * rtt);
 }
 
 static void icall_quality_handler(struct icall *icall,


### PR DESCRIPTION
WPB-24323: Iterate on network quality index

Quality index is calculated [wrt latency, packet loss and jitter.](https://wearezeta.atlassian.net/wiki/spaces/PAD/pages/2520252449/2026-01-29+RFC+Call+Details+Network+Quality+Interface)
All stats are 3 level quantized wrt min and max thresholds.
Upstream metrics are weighted more than downstrem ones (0.7 vs 0.3)
Over quality index is calculated with weighted average;

NQI = 0.35 * loss + 0.35 * latency + 0.3 * jitter

