### PR TITLE
feat: Calculate downstream rtt from remote rtp reports (WPB-24323)

### DIFF
--- a/include/avs_stats.h
+++ b/include/avs_stats.h
@@ -63,7 +63,7 @@ struct stats_report {
 	struct stats_packet_counts packets_per_sec;
 	int audio_level;
 	int audio_level_smooth;
-	int rtt;
+	struct stats_rx_tx rtt;
 };
 
 int stats_alloc(struct avs_stats **statsp, void *arg);

--- a/src/ecall/ecall.c
+++ b/src/ecall/ecall.c
@@ -3319,7 +3319,7 @@ static void quality_handler(void *arg)
 
 	if (!err) {
 		uint32_t dloss = (uint32_t)stats.packets.lost.rx;
-		uint32_t rtt = (uint32_t)stats.rtt;
+		uint32_t rtt = stats.rtt.tx;
 		ICALL_CALL_CB(ecall->icall, qualityh,
 			      &ecall->icall,
 			      ecall->userid_peer,

--- a/src/stats/stats.c
+++ b/src/stats/stats.c
@@ -241,7 +241,7 @@ static uint64_t normalize_timestamp_to_ms(double timestamp) {
 	return (uint64_t)timestamp;
 }
 
-static int read_packet_stats_and_jitter(struct avs_stats *stats, const struct stats_obj* stats_obj)
+static int read_packet_stats_and_jitter(struct avs_stats *stats, const struct stats_obj *stats_obj)
 {
 	struct le *le = NULL;
 	double audio_jitter = 0;
@@ -270,7 +270,7 @@ static int read_packet_stats_and_jitter(struct avs_stats *stats, const struct st
 
 	// 1. read json stats into report
 	LIST_FOREACH(&stats_obj->inbound_rtp, le) {
-		const struct stats_inbound_rtp* data = (struct stats_inbound_rtp*)le->data;
+		const struct stats_inbound_rtp *data = (struct stats_inbound_rtp *)le->data;
 
 		if (data->kind == STATS_KIND_AUDIO) {
 			stats->report.packets.audio.rx += data->packets_received;
@@ -293,7 +293,7 @@ static int read_packet_stats_and_jitter(struct avs_stats *stats, const struct st
 	}
 
 	LIST_FOREACH(&stats_obj->outbound_rtp, le) {
-		const struct stats_outbound_rtp* data = (struct stats_outbound_rtp*)le->data;
+		const struct stats_outbound_rtp *data = (struct stats_outbound_rtp *)le->data;
 
 		if (data->kind == STATS_KIND_AUDIO) {
 			stats->report.packets.audio.tx += data->packets_sent;
@@ -306,7 +306,7 @@ static int read_packet_stats_and_jitter(struct avs_stats *stats, const struct st
 	}
 
 	LIST_FOREACH(&stats_obj->remote_inbound_rtp, le) {
-		const struct stats_remote_inbound_rtp* data = (struct stats_remote_inbound_rtp*)le->data;
+		const struct stats_remote_inbound_rtp *data = (struct stats_remote_inbound_rtp *)le->data;
 
 		if (data->kind == STATS_KIND_AUDIO) {
 			stats->report.jitter.audio.tx = max(stats->report.jitter.audio.tx, (1000 * data->jitter));
@@ -366,7 +366,7 @@ static int read_packet_stats_and_jitter(struct avs_stats *stats, const struct st
 }
 
 // Helper function to read percieved rtt
-static void read_rtt_rx(struct avs_stats *stats, const struct stats_obj* stats_obj)
+static void read_rtt_rx(struct avs_stats *stats, const struct stats_obj *stats_obj)
 {
 	struct le *le = NULL;
 
@@ -379,9 +379,9 @@ static void read_rtt_rx(struct avs_stats *stats, const struct stats_obj* stats_o
 	int remote_inbound_rtt_count = 0;
 
 	LIST_FOREACH(&stats_obj->remote_inbound_rtp, le) {
-		const struct stats_remote_inbound_rtp* data = (struct stats_remote_inbound_rtp*)le->data;
+		const struct stats_remote_inbound_rtp *data = (struct stats_remote_inbound_rtp *)le->data;
 
-		if (data->kind == STATS_KIND_AUDIO ||data->kind == STATS_KIND_VIDEO) {
+		if (data->kind == STATS_KIND_AUDIO || data->kind == STATS_KIND_VIDEO) {
 			remote_inbound_rtt += data->rtt;
 			remote_inbound_rtt_count++;
 		}
@@ -390,11 +390,11 @@ static void read_rtt_rx(struct avs_stats *stats, const struct stats_obj* stats_o
 	stats->report.rtt.rx = remote_inbound_rtt ? 1000 * (remote_inbound_rtt / remote_inbound_rtt_count) : 0;
 }
 
-static int read_rtt_and_connection(struct avs_stats *stats, const struct stats_obj* stats_obj)
+static int read_rtt_and_connection(struct avs_stats *stats, const struct stats_obj *stats_obj)
 {
 	struct le *le = NULL;
-	const char* connected_local_candidate_id = NULL;
-	const char* selected_pair_id = NULL;
+	const char *connected_local_candidate_id = NULL;
+	const char *selected_pair_id = NULL;
 
 	if (!stats || !stats_obj) {
 		return EINVAL;
@@ -410,7 +410,7 @@ static int read_rtt_and_connection(struct avs_stats *stats, const struct stats_o
 	// When we have a "transport" report search selected pair, else
 	// search a connected pair (which is succeeded and nominated)
 	LIST_FOREACH(&stats_obj->candidate_pair, le) {
-		const struct stats_candidate_pair* data = (struct stats_candidate_pair*)le->data;
+		const struct stats_candidate_pair *data = (struct stats_candidate_pair *)le->data;
 
 		if (selected_pair_id) {
 			if (data->id && streq(selected_pair_id, data->id)) {
@@ -439,7 +439,7 @@ static int read_rtt_and_connection(struct avs_stats *stats, const struct stats_o
 	}
 	// use last connected local candidate id to get connection details
 	LIST_FOREACH(&stats_obj->local_candidate, le) {
-		const struct stats_local_candidate* data = (struct stats_local_candidate*)le->data;
+		const struct stats_local_candidate *data = (struct stats_local_candidate *)le->data;
 
 		if (data->id && streq(data->id, connected_local_candidate_id)) {
 			stats->report.proto = data->proto;
@@ -451,7 +451,7 @@ static int read_rtt_and_connection(struct avs_stats *stats, const struct stats_o
 	return 0;
 }
 
-static int read_audio_level(struct avs_stats *stats, const struct stats_obj* stats_obj)
+static int read_audio_level(struct avs_stats *stats, const struct stats_obj *stats_obj)
 {
 	struct le *le = NULL;
 
@@ -460,7 +460,7 @@ static int read_audio_level(struct avs_stats *stats, const struct stats_obj* sta
 	}
 
 	LIST_FOREACH(&stats_obj->audio_source, le) {
-		const struct stats_audio_source* asp = (struct stats_audio_source*)le->data;
+		const struct stats_audio_source *asp = (struct stats_audio_source *)le->data;
 		stats->report.audio_level = (int)(asp->level * 255.0);
 	}
 
@@ -496,11 +496,11 @@ int stats_alloc(struct avs_stats **statsp, void *arg)
 }
 
 
-static struct stats_inbound_rtp* parse_inbound_rtp(struct json_object *jitem)
+static struct stats_inbound_rtp *parse_inbound_rtp(struct json_object *jitem)
 {
-	const char* kind_str = NULL;
+	const char *kind_str = NULL;
 
-	struct stats_inbound_rtp* data;
+	struct stats_inbound_rtp *data;
 	data = mem_zalloc(sizeof(*data), NULL);
 	memset(data, 0, sizeof(*data));
 
@@ -515,9 +515,9 @@ static struct stats_inbound_rtp* parse_inbound_rtp(struct json_object *jitem)
 	return data;
 }
 
-static struct stats_outbound_rtp* parse_outbound_rtp(struct json_object *jitem)
+static struct stats_outbound_rtp *parse_outbound_rtp(struct json_object *jitem)
 {
-	const char* kind_str = NULL;
+	const char *kind_str = NULL;
 
 	struct stats_outbound_rtp* data;
 	data = mem_zalloc(sizeof(*data), NULL);
@@ -532,11 +532,11 @@ static struct stats_outbound_rtp* parse_outbound_rtp(struct json_object *jitem)
 	return data;
 }
 
-static struct stats_remote_inbound_rtp* parse_remote_inbound_rtp(struct json_object *jitem)
+static struct stats_remote_inbound_rtp *parse_remote_inbound_rtp(struct json_object *jitem)
 {
-	const char* kind_str = NULL;
+	const char *kind_str = NULL;
 
-	struct stats_remote_inbound_rtp* data;
+	struct stats_remote_inbound_rtp *data;
 	data = mem_zalloc(sizeof(*data), NULL);
 	memset(data, 0, sizeof(*data));
 
@@ -592,9 +592,9 @@ static struct stats_candidate_pair *parse_candidate_pair(struct json_object *jit
 
 static struct stats_local_candidate *parse_local_candidate(struct json_object *jitem)
 {
-	const char* id_str = NULL;
-	const char* proto_str = NULL;
-	const char* cand_str = NULL;
+	const char *id_str = NULL;
+	const char *proto_str = NULL;
+	const char *cand_str = NULL;
 
 	struct stats_local_candidate *data;
 	data = mem_zalloc(sizeof(*data),local_candidate_destructor);
@@ -627,9 +627,9 @@ static struct stats_transport *parse_transport(struct json_object *jitem)
 	return data;
 }
 
-static int parse_json(const char *report, struct stats_obj* stats_obj) {
-	const char* type_str = NULL;
-	const char* kind_str = NULL;
+static int parse_json(const char *report, struct stats_obj *stats_obj) {
+	const char *type_str = NULL;
+	const char *kind_str = NULL;
 	int err = 0;
 
 	if (!report || !stats_obj) {
@@ -667,7 +667,7 @@ static int parse_json(const char *report, struct stats_obj* stats_obj) {
 
 		switch (type) {
 			case STATS_TYPE_INBOUND_RTP: {
-				struct stats_inbound_rtp* irp = NULL;
+				struct stats_inbound_rtp *irp = NULL;
 				irp = parse_inbound_rtp(jitem);
 				if (irp) {
 					list_append(&stats_obj->inbound_rtp, &irp->le, irp);
@@ -676,7 +676,7 @@ static int parse_json(const char *report, struct stats_obj* stats_obj) {
 				break;
 
 			case STATS_TYPE_OUTBOUND_RTP: {
-				struct stats_outbound_rtp* orp = NULL;
+				struct stats_outbound_rtp *orp = NULL;
 				orp = parse_outbound_rtp(jitem);
 				if (orp) {
 					list_append(&stats_obj->outbound_rtp, &orp->le, orp);
@@ -685,7 +685,7 @@ static int parse_json(const char *report, struct stats_obj* stats_obj) {
 				break;
 
 			case STATS_TYPE_REMOTE_INBOUND_RTP: {
-				struct stats_remote_inbound_rtp* rirp = NULL;
+				struct stats_remote_inbound_rtp *rirp = NULL;
 				rirp = parse_remote_inbound_rtp(jitem);
 				if (rirp) {
 					list_append(&stats_obj->remote_inbound_rtp, &rirp->le, rirp);
@@ -699,7 +699,7 @@ static int parse_json(const char *report, struct stats_obj* stats_obj) {
 				enum stats_kind kind = stats_parse_kind(kind_str);
 
 				if (kind == STATS_KIND_AUDIO) {
-					struct stats_audio_source* asp = NULL;
+					struct stats_audio_source *asp = NULL;
 					asp = parse_audio_source(jitem);
 					if (asp) {
 						list_append(&stats_obj->audio_source, &asp->le, asp);
@@ -709,7 +709,7 @@ static int parse_json(const char *report, struct stats_obj* stats_obj) {
 				break;
 
 			case STATS_TYPE_CANDIDATE_PAIR: {
-				struct stats_candidate_pair* cp = NULL;
+				struct stats_candidate_pair *cp = NULL;
 				cp = parse_candidate_pair(jitem);
 				if (cp) {
 					list_append(&stats_obj->candidate_pair, &cp->le, cp);
@@ -718,7 +718,7 @@ static int parse_json(const char *report, struct stats_obj* stats_obj) {
 				break;
 
 			case STATS_TYPE_LOCAL_CANDIDATE: {
-				struct stats_local_candidate* lc = NULL;
+				struct stats_local_candidate *lc = NULL;
 				lc = parse_local_candidate(jitem);
 				if (lc) {
 					list_append(&stats_obj->local_candidate, &lc->le, lc);
@@ -727,7 +727,7 @@ static int parse_json(const char *report, struct stats_obj* stats_obj) {
 				break;
 
 			case STATS_TYPE_TRANSPORT: {
-				struct stats_transport* tr = NULL;
+				struct stats_transport *tr = NULL;
 				tr = parse_transport(jitem);
 				if (tr) {
 					list_append(&stats_obj->transport, &tr->le, tr);

--- a/src/stats/stats.c
+++ b/src/stats/stats.c
@@ -153,6 +153,7 @@ struct stats_remote_inbound_rtp {
 	int packets_lost;
 	double jitter;
 	double timestamp;
+	double rtt;
 	struct le le;
 };
 
@@ -388,7 +389,7 @@ static int read_rtt_and_connection(struct avs_stats *stats, struct stats_obj* st
 
 		if (selected_pair_id) {
 			if (data->id && streq(selected_pair_id, data->id)) {
-				stats->report.rtt = max(stats->report.rtt, (1000 * data->current_rtt));
+				stats->report.rtt.tx = max(stats->report.rtt.tx, (1000 * data->current_rtt));
 				connected_local_candidate_id = data->local_candidate_id;
 				break;
 			}
@@ -396,7 +397,7 @@ static int read_rtt_and_connection(struct avs_stats *stats, struct stats_obj* st
 		else {
 			// we will try to find connected pair without "transport" info
 			if (data->nominated && (data->state == STATS_STATE_SUCCEEDED)) {
-				stats->report.rtt = max(stats->report.rtt, (1000 * data->current_rtt));
+				stats->report.rtt.tx = max(stats->report.rtt.tx, (1000 * data->current_rtt));
 				if (data->local_candidate_id) {
 					connected_local_candidate_id = data->local_candidate_id;
 				}
@@ -404,11 +405,25 @@ static int read_rtt_and_connection(struct avs_stats *stats, struct stats_obj* st
 		}
 	}
 
+	// Calculate mean rtt rx (perceived from peer) from remote inbound reports
+	double remote_inbound_rtt = 0;
+	int remote_inbound_rtt_count = 0;
+
+	LIST_FOREACH(&stats_obj->remote_inbound_rtp, le) {
+		struct stats_remote_inbound_rtp* data = (struct stats_remote_inbound_rtp*)le->data;
+
+		if (data->kind == STATS_KIND_AUDIO ||data->kind == STATS_KIND_VIDEO) {
+			remote_inbound_rtt += data->rtt;
+			remote_inbound_rtt_count++;
+		}
+	}
+
+	stats->report.rtt.rx = remote_inbound_rtt ? 1000 * (remote_inbound_rtt / remote_inbound_rtt_count) : 0;
+
 	if (!connected_local_candidate_id) {
 		// maybe ok that we dont have connection atm
 		return 0;
 	}
-
 	// use last connected local candidate id to get connection details
 	LIST_FOREACH(&stats_obj->local_candidate, le) {
 		struct stats_local_candidate* data = (struct stats_local_candidate*)le->data;
@@ -518,6 +533,7 @@ static struct stats_remote_inbound_rtp* parse_remote_inbound_rtp(struct json_obj
 	jzon_int(&data->packets_lost, jitem, "packetsLost");
 	jzon_double(&data->jitter, jitem, "jitter");
 	jzon_double(&data->timestamp, jitem, "timestamp");
+	jzon_double(&data->rtt, jitem, "roundTripTime");
 
 	return data;
 }

--- a/src/stats/stats.c
+++ b/src/stats/stats.c
@@ -241,7 +241,7 @@ static uint64_t normalize_timestamp_to_ms(double timestamp) {
 	return (uint64_t)timestamp;
 }
 
-static int read_packet_stats_and_jitter(struct avs_stats *stats, struct stats_obj* stats_obj)
+static int read_packet_stats_and_jitter(struct avs_stats *stats, const struct stats_obj* stats_obj)
 {
 	struct le *le = NULL;
 	double audio_jitter = 0;
@@ -270,7 +270,7 @@ static int read_packet_stats_and_jitter(struct avs_stats *stats, struct stats_ob
 
 	// 1. read json stats into report
 	LIST_FOREACH(&stats_obj->inbound_rtp, le) {
-		struct stats_inbound_rtp* data = (struct stats_inbound_rtp*)le->data;
+		const struct stats_inbound_rtp* data = (struct stats_inbound_rtp*)le->data;
 
 		if (data->kind == STATS_KIND_AUDIO) {
 			stats->report.packets.audio.rx += data->packets_received;
@@ -293,7 +293,7 @@ static int read_packet_stats_and_jitter(struct avs_stats *stats, struct stats_ob
 	}
 
 	LIST_FOREACH(&stats_obj->outbound_rtp, le) {
-		struct stats_outbound_rtp* data = (struct stats_outbound_rtp*)le->data;
+		const struct stats_outbound_rtp* data = (struct stats_outbound_rtp*)le->data;
 
 		if (data->kind == STATS_KIND_AUDIO) {
 			stats->report.packets.audio.tx += data->packets_sent;
@@ -306,7 +306,7 @@ static int read_packet_stats_and_jitter(struct avs_stats *stats, struct stats_ob
 	}
 
 	LIST_FOREACH(&stats_obj->remote_inbound_rtp, le) {
-		struct stats_remote_inbound_rtp* data = (struct stats_remote_inbound_rtp*)le->data;
+		const struct stats_remote_inbound_rtp* data = (struct stats_remote_inbound_rtp*)le->data;
 
 		if (data->kind == STATS_KIND_AUDIO) {
 			stats->report.jitter.audio.tx = max(stats->report.jitter.audio.tx, (1000 * data->jitter));
@@ -365,7 +365,32 @@ static int read_packet_stats_and_jitter(struct avs_stats *stats, struct stats_ob
 	return 0;
 }
 
-static int read_rtt_and_connection(struct avs_stats *stats, struct stats_obj* stats_obj)
+// Helper function to read percieved rtt
+static void read_rtt_rx(struct avs_stats *stats, const struct stats_obj* stats_obj)
+{
+	struct le *le = NULL;
+
+	if (!stats || !stats_obj) {
+		return;
+	}
+
+	// Calculate mean rtt from remote inbound reports
+	double remote_inbound_rtt = 0;
+	int remote_inbound_rtt_count = 0;
+
+	LIST_FOREACH(&stats_obj->remote_inbound_rtp, le) {
+		const struct stats_remote_inbound_rtp* data = (struct stats_remote_inbound_rtp*)le->data;
+
+		if (data->kind == STATS_KIND_AUDIO ||data->kind == STATS_KIND_VIDEO) {
+			remote_inbound_rtt += data->rtt;
+			remote_inbound_rtt_count++;
+		}
+	}
+
+	stats->report.rtt.rx = remote_inbound_rtt ? 1000 * (remote_inbound_rtt / remote_inbound_rtt_count) : 0;
+}
+
+static int read_rtt_and_connection(struct avs_stats *stats, const struct stats_obj* stats_obj)
 {
 	struct le *le = NULL;
 	const char* connected_local_candidate_id = NULL;
@@ -378,14 +403,14 @@ static int read_rtt_and_connection(struct avs_stats *stats, struct stats_obj* st
 	// First check if there is a "transport" report that should have selected pair
 	le = list_head(&stats_obj->transport);
 	if (le) {
-		struct stats_transport *head = (struct stats_transport*)le->data;
+		const struct stats_transport *head = (struct stats_transport*)le->data;
 		selected_pair_id = head->selected_pair_id;
 	}
 
 	// When we have a "transport" report search selected pair, else
 	// search a connected pair (which is succeeded and nominated)
 	LIST_FOREACH(&stats_obj->candidate_pair, le) {
-		struct stats_candidate_pair* data = (struct stats_candidate_pair*)le->data;
+		const struct stats_candidate_pair* data = (struct stats_candidate_pair*)le->data;
 
 		if (selected_pair_id) {
 			if (data->id && streq(selected_pair_id, data->id)) {
@@ -405,20 +430,8 @@ static int read_rtt_and_connection(struct avs_stats *stats, struct stats_obj* st
 		}
 	}
 
-	// Calculate mean rtt rx (perceived from peer) from remote inbound reports
-	double remote_inbound_rtt = 0;
-	int remote_inbound_rtt_count = 0;
-
-	LIST_FOREACH(&stats_obj->remote_inbound_rtp, le) {
-		struct stats_remote_inbound_rtp* data = (struct stats_remote_inbound_rtp*)le->data;
-
-		if (data->kind == STATS_KIND_AUDIO ||data->kind == STATS_KIND_VIDEO) {
-			remote_inbound_rtt += data->rtt;
-			remote_inbound_rtt_count++;
-		}
-	}
-
-	stats->report.rtt.rx = remote_inbound_rtt ? 1000 * (remote_inbound_rtt / remote_inbound_rtt_count) : 0;
+	// read rtt perceived from peer side
+	read_rtt_rx(stats, stats_obj);
 
 	if (!connected_local_candidate_id) {
 		// maybe ok that we dont have connection atm
@@ -426,7 +439,7 @@ static int read_rtt_and_connection(struct avs_stats *stats, struct stats_obj* st
 	}
 	// use last connected local candidate id to get connection details
 	LIST_FOREACH(&stats_obj->local_candidate, le) {
-		struct stats_local_candidate* data = (struct stats_local_candidate*)le->data;
+		const struct stats_local_candidate* data = (struct stats_local_candidate*)le->data;
 
 		if (data->id && streq(data->id, connected_local_candidate_id)) {
 			stats->report.proto = data->proto;
@@ -438,7 +451,7 @@ static int read_rtt_and_connection(struct avs_stats *stats, struct stats_obj* st
 	return 0;
 }
 
-static int read_audio_level(struct avs_stats *stats, struct stats_obj* stats_obj)
+static int read_audio_level(struct avs_stats *stats, const struct stats_obj* stats_obj)
 {
 	struct le *le = NULL;
 
@@ -447,7 +460,7 @@ static int read_audio_level(struct avs_stats *stats, struct stats_obj* stats_obj
 	}
 
 	LIST_FOREACH(&stats_obj->audio_source, le) {
-		struct stats_audio_source* asp = (struct stats_audio_source*)le->data;
+		const struct stats_audio_source* asp = (struct stats_audio_source*)le->data;
 		stats->report.audio_level = (int)(asp->level * 255.0);
 	}
 

--- a/src/wcall/wcall.c
+++ b/src/wcall/wcall.c
@@ -1653,13 +1653,15 @@ const float RTT_WEIGHT = 0.3;
 
 static int normalize_quality(const struct stats_report* stats) {
 	// Stats are 3 step normalized wrt corresponding thresholds
-	const int rtt = normalize_to_levels(stats->rtt, RTT_LOW, RTT_HIGH);
+	const int rtt_tx = normalize_to_levels(stats->rtt.tx, RTT_LOW, RTT_HIGH);
+	const int rtt_rx = normalize_to_levels(stats->rtt.rx, RTT_LOW, RTT_HIGH);
 	const int jitter_tx = normalize_to_levels((stats->jitter.audio.tx + stats->jitter.video.tx) / 2, JITTER_LOW, JITTER_HIGH);
 	const int jitter_rx = normalize_to_levels((stats->jitter.audio.rx + stats->jitter.video.rx) / 2, JITTER_LOW, JITTER_HIGH);
 	const int packet_loss_tx = normalize_to_levels(stats->packets.lost.tx, PACKET_LOSS_LOW, PACKET_LOSS_HIGH);
 	const int packet_loss_rx = normalize_to_levels(stats->packets.lost.rx, PACKET_LOSS_LOW, PACKET_LOSS_HIGH);
 
 	// provide higher importance to upstream stats
+	float rtt = UPSTREAM_WEIGHT * rtt_tx + DOWNSTREM_WEIGHT * rtt_rx;
 	float jitter = UPSTREAM_WEIGHT * jitter_tx + DOWNSTREM_WEIGHT * jitter_rx;
 	float packet_loss = UPSTREAM_WEIGHT * packet_loss_tx + DOWNSTREM_WEIGHT * packet_loss_rx;
 
@@ -1717,7 +1719,7 @@ static void icall_quality_handler(struct icall *icall,
 	json_object_object_add(jobj, "quality",
 				json_object_new_int(quality));
 	json_object_object_add(jobj, "rtt",
-				json_object_new_int(stats.rtt));
+				json_object_new_int(stats.rtt.tx));
 
 	struct json_object *loss_jobj = json_object_new_object();
 	json_object_object_add(loss_jobj, "tx",

--- a/src/wcall/wcall.c
+++ b/src/wcall/wcall.c
@@ -1644,12 +1644,12 @@ const int PACKET_LOSS_HIGH = 10;
 
 // Stream direction weights
 const float UPSTREAM_WEIGHT = 0.7;
-const float DOWNSTREM_WEIGHT = 0.3;
+const float DOWNSTREM_WEIGHT = (1.0 - UPSTREAM_WEIGHT);
 
 // Overall quality weights
 const float JITTER_WEIGHT = 0.35;
 const float PACKET_LOSS_WEIGHT = 0.35;
-const float RTT_WEIGHT = 0.3;
+const float RTT_WEIGHT = (1.0 - JITTER_WEIGHT - PACKET_LOSS_WEIGHT);
 
 static int normalize_quality(const struct stats_report* stats) {
 	// Stats are 3 step normalized wrt corresponding thresholds

--- a/test/test_stats.cpp
+++ b/test/test_stats.cpp
@@ -520,7 +520,7 @@ public:
 		Base::TearDown();
 	}
 
-protected:
+public:
 	RTCIceCandidatePairStats* candidate_pair;
 	const stats_rx_tx zero_rtt = {0, 0};
 };
@@ -591,7 +591,7 @@ public:
 		Base::TearDown();
 	}
 
-protected:
+public:
 	RTCIceCandidatePairStats* candidate_pair;
 	stats_rx_tx expected_rtt;
 };

--- a/test/test_stats.cpp
+++ b/test/test_stats.cpp
@@ -502,18 +502,18 @@ TEST_F(StatsJitter, zero_packet_rtp)
 }
 
 // ------------------------------------- RTT Tests --------------------------------------
-class StatsRtt: public Base,
+class StatsRttBase: public Base,
 				public ::testing::Test {
 public:
 	void SetUp() override
 	{
 		Base::SetUp();
 
+		auto empty_candidate_pair = new RTCIceCandidatePairStats("emptyCandidatePair", Timestamp::Zero());
+		report->AddStats(std::unique_ptr<RTCStats>(empty_candidate_pair));
+
 		candidate_pair = new RTCIceCandidatePairStats("candidatePair", Timestamp::Zero());
 		candidate_pair->current_round_trip_time = 0.01;
-		auto empty_candidate_pair = new RTCIceCandidatePairStats("emptyCandidatePair", Timestamp::Zero());
-		report->AddStats(std::unique_ptr<RTCStats>(candidate_pair));
-		report->AddStats(std::unique_ptr<RTCStats>(empty_candidate_pair));
 	}
 
 	void TearDown() override {
@@ -522,10 +522,10 @@ public:
 
 protected:
 	RTCIceCandidatePairStats* candidate_pair;
-	const int zero_rtt = 0;
+	const stats_rx_tx zero_rtt = {0, 0};
 };
 
-TEST_F(StatsRtt, without_candidates)
+TEST_F(StatsRttBase, without_candidates)
 {
 	stats_update(stats, report->ToJson().c_str());
 	stats_get_report(stats, &sr);
@@ -533,9 +533,10 @@ TEST_F(StatsRtt, without_candidates)
 	EXPECT_EQ(sr.rtt, zero_rtt);
 }
 
-TEST_F(StatsRtt, unsucceeded_candidates)
+TEST_F(StatsRttBase, unsucceeded_candidates)
 {
 	candidate_pair->state = "unsucceeded";
+	report->AddStats(std::unique_ptr<RTCStats>(candidate_pair));
 
 	stats_update(stats, report->ToJson().c_str());
 	stats_get_report(stats, &sr);
@@ -543,10 +544,11 @@ TEST_F(StatsRtt, unsucceeded_candidates)
 	EXPECT_EQ(sr.rtt, zero_rtt);
 }
 
-TEST_F(StatsRtt, unnominated_candidates)
+TEST_F(StatsRttBase, unnominated_candidates)
 {
 	candidate_pair->state = "succeeded";
 	candidate_pair->nominated = false;
+	report->AddStats(std::unique_ptr<RTCStats>(candidate_pair));
 
 	stats_update(stats, report->ToJson().c_str());
 	stats_get_report(stats, &sr);
@@ -554,14 +556,49 @@ TEST_F(StatsRtt, unnominated_candidates)
 	EXPECT_EQ(sr.rtt, zero_rtt);
 }
 
+// ------------------------------------- RTT Tests --------------------------------------
+class StatsRtt: public StatsRttBase {
+public:
+	void SetUp() override
+	{
+		Base::SetUp();
+
+		candidate_pair = new RTCIceCandidatePairStats("candidatePair", Timestamp::Zero());
+
+		auto empty_candidate_pair = new RTCIceCandidatePairStats("emptyCandidatePair", Timestamp::Zero());
+		report->AddStats(std::unique_ptr<RTCStats>(empty_candidate_pair));
+
+		candidate_pair->current_round_trip_time = 0.01;
+		candidate_pair->state = "succeeded";
+		candidate_pair->nominated = true;
+		report->AddStats(std::unique_ptr<RTCStats>(candidate_pair));
+
+		const auto remote_audio_rtp = new RTCRemoteInboundRtpStreamStats("someRemoteAudioRtpId", Timestamp::Zero());
+		remote_audio_rtp->kind = "audio";
+		remote_audio_rtp->round_trip_time = 0.06;
+		report->AddStats(std::unique_ptr<RTCStats>(remote_audio_rtp));
+
+		const auto remote_video_rtp = new RTCRemoteInboundRtpStreamStats("someRemoteVideoRtpId", Timestamp::Zero());
+		remote_video_rtp->kind = "video";
+		remote_video_rtp->round_trip_time = 0.04;
+		report->AddStats(std::unique_ptr<RTCStats>(remote_video_rtp));
+
+		expected_rtt.tx = 1000 * (*candidate_pair->current_round_trip_time);
+		expected_rtt.rx = 1000 * (*remote_audio_rtp->round_trip_time + *remote_video_rtp->round_trip_time) / 2;
+	}
+
+	void TearDown() override {
+		Base::TearDown();
+	}
+
+protected:
+	RTCIceCandidatePairStats* candidate_pair;
+	stats_rx_tx expected_rtt;
+};
+
+
 TEST_F(StatsRtt, some_rtt_values)
 {
-	const auto expected_rtt = 10;
-
-	candidate_pair->state = "succeeded";
-	candidate_pair->nominated = true;
-	candidate_pair->current_round_trip_time = 0.01;
-
 	stats_update(stats, report->ToJson().c_str());
 	stats_get_report(stats, &sr);
 
@@ -570,12 +607,6 @@ TEST_F(StatsRtt, some_rtt_values)
 
 TEST_F(StatsRtt, some_rtt_values_with_transport)
 {
-	const auto expected_rtt = 10;
-
-	candidate_pair->state = "succeeded";
-	candidate_pair->nominated = true;
-	candidate_pair->current_round_trip_time = 0.01;
-
 	auto transport = new RTCTransportStats("someTransportId", Timestamp::Zero());
 	transport->selected_candidate_pair_id = candidate_pair->id();
 	report->AddStats(std::unique_ptr<RTCStats>(transport));


### PR DESCRIPTION
Calculate downstream rtt from mean of remote rtp reports. These values depend on rtcp reports, and represent perceived rtt of remote.