### PR TITLE
Push kmp ios package to maven central (WPB-24450)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -284,7 +284,7 @@ pipeline {
                             sh(
                                 script: """
                                     touch local.properties
-                                    ORG_GRADLE_PROJECT_VERSION_NAME=$version ./gradlew publishAndReleaseToMavenCentral
+                                    ORG_GRADLE_PROJECT_VERSION_NAME=$version ./gradlew :publishAndReleaseToMavenCentral
                                 """
                             )
                         }
@@ -293,9 +293,43 @@ pipeline {
             }
         }
 
-        // WPB-22450 Push ios avs to Maven central
-        // ios build will require macos agent
-        // ORG_GRADLE_PROJECT_VERSION_NAME=$version ./gradlew publisIos64ToMavenCentral
+        // WPB-24450 Temporary dublication to make seperaton of classical android and new kmp publish.
+        // "Publish to sonatype" stage will be removed with introduction of android kmp
+        // where "Publish kmp to sonatype" will probably then use matrix.axes to minimize dublication
+        // between linux and macos tasks.
+        stage('Publish kmp to sonatype') {
+            when {
+                anyOf {
+                    expression { return "${branchName}".contains('release') }
+                }
+            }
+            agent {
+                label 'macos'
+            }
+            environment {
+                PATH = "/opt/homebrew/bin:/Applications/Xcode.app/Contents/Developer/usr/bin:/Users/jenkins/.cargo/bin:/usr/local/bin:${ env.PATH }"
+            }
+            steps {
+                script {
+                    echo '### Sign and upload to sonatype'
+                    withCredentials([
+                            usernamePassword( credentialsId: 'sonatype-central', usernameVariable: 'ORG_GRADLE_PROJECT_mavenCentralUsername', passwordVariable: 'ORG_GRADLE_PROJECT_mavenCentralPassword' ),
+                            string(credentialsId: 'sonatype-signing-key-password', variable: 'ORG_GRADLE_PROJECT_signingInMemoryKeyPassword'),
+                            string(credentialsId: 'sonatype-signing-key', variable: 'ORG_GRADLE_PROJECT_signingInMemoryKey')
+                        ]) {
+                        withMaven(maven: 'M3', jdk: 'JDK17') {
+                            sh(
+                                script: """
+                                    touch local.properties
+                                    ORG_GRADLE_PROJECT_VERSION_NAME=$version ./gradlew avs:clean
+                                    ORG_GRADLE_PROJECT_VERSION_NAME=$version ./gradlew :avs:publishAndReleaseToMavenCentral --no-configuration-cache
+                                """
+                            )
+                        }
+                    }
+                }
+            }
+        }
 
 //        stage('Publish to ios github repo') {
 //            when {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import com.vanniktech.maven.publish.JavaLibrary
 
 plugins {
     id "java-library"
-    id("com.vanniktech.maven.publish.base") version "0.34.0"
+    id("com.vanniktech.maven.publish.base") version "0.36.0"
     id("org.jetbrains.kotlin.multiplatform") version "2.2.21" apply false
 }
 

--- a/kmp/build.gradle.kts
+++ b/kmp/build.gradle.kts
@@ -4,7 +4,7 @@ import java.io.File
 
 plugins {
     kotlin("multiplatform") version "2.2.21"
-    id("com.vanniktech.maven.publish.base") version "0.34.0"
+    id("com.vanniktech.maven.publish.base") version "0.36.0"
 }
 
 group = findProperty("GROUP") as String? ?: "com.wire"
@@ -104,5 +104,38 @@ kotlin {
 tasks.withType<Sign>().configureEach {
     if (System.getenv("CI") == null) {
         enabled = false
+    }
+}
+
+mavenPublishing {
+    publishToMavenCentral(automaticRelease = true)
+    signAllPublications()
+    pom {
+        name.set(findProperty("POM_NAME") as String)
+        description.set(findProperty("POM_DESCRIPTION") as String)
+        url.set(findProperty("POM_URL") as String)
+
+        licenses {
+            license {
+                name.set(findProperty("POM_LICENCE_NAME") as String)
+                url.set(findProperty("POM_LICENCE_URL") as String)
+                distribution.set(findProperty("POM_LICENSE_DIST") as String)
+            }
+        }
+
+        scm {
+            url.set(findProperty("POM_SCM_URL") as String)
+            connection.set(findProperty("POM_SCM_CONNECTION") as String)
+            developerConnection.set(findProperty("POM_SCM_DEV_CONNECTION") as String)
+        }
+
+        developers {
+            developer {
+                name.set(findProperty("POM_DEVELOPER_NAME") as String)
+                email.set(findProperty("POM_DEVELOPER_EMAIL") as String)
+                organization.set(findProperty("POM_NAME") as String)
+                organizationUrl.set(findProperty("POM_URL") as String)
+            }
+        }
     }
 }


### PR DESCRIPTION
Push kmp ios package to maven central

During migration android package will still be published as
- com.wire.avs

And ios kmp packages will be published as
- com.wire.avs-kmp
- com.wire.avs-kmp-iosarm64
- com.wire.avs-kmp-iossimulatorarm64

Next steps will be having android package in kmp

[maven central](https://central.sonatype.com/search?q=wire%20avs)

Sample View from tryout branch/version 0.0.x
<img width="1354" height="763" alt="Screenshot from 2026-04-17 14-15-33" src="https://github.com/user-attachments/assets/96791977-5986-4681-ae97-4e98980f1f92" />

and legacy android (as before)
<img width="1143" height="927" alt="Screenshot from 2026-04-17 14-18-43" src="https://github.com/user-attachments/assets/c1ab3a29-bfdc-482b-97ae-d25cf280b616" />
