### PR TITLE
iOS AU crash

### DIFF
--- a/src/audio_io/ios/audio_io_ios.h
+++ b/src/audio_io/ios/audio_io_ios.h
@@ -282,6 +282,7 @@ private:
 	pthread_t rec_tid_ = 0;
 	std::atomic<bool> is_recording_;
 	std::atomic<bool> is_playing_;
+	std::atomic<bool> is_au_started_;
 	volatile bool is_recording_initialized_;
 	volatile bool is_playing_initialized_;
 

--- a/src/audio_io/ios/audio_io_ios.mm
+++ b/src/audio_io/ios/audio_io_ios.mm
@@ -193,11 +193,23 @@ int32_t audio_io_ios::StartPlayoutInternal(void)
 	play_out_pos_ = 0;
         
         if (!is_recording_.load()) {
-            OSStatus result = AudioOutputUnitStart(au_);
-            if (result != noErr) {
-                error("audio_io_ios: AudioOutputUnitStart failed:0x%08x\n", result);
-                return -1;
-            }
+		if (!is_au_started_.load()) {
+			dispatch_sync(dispatch_get_main_queue(), ^{
+				OSStatus result = -1;
+				if (nullptr != au_) {
+					result = AudioOutputUnitStart(au_);
+					if (result != noErr) {
+						error("audio_io_ios: AudioOutputUnitStart failed:0x%08x\n", result);
+						is_playing_.store(false);
+						is_au_started_.store(false);
+					}
+					else {
+						info("audio_io_ios: AudioOutputUnitStart success\n");
+						is_au_started_.store(true);
+					}
+				}
+			});
+		}
         }
         is_playing_.store(true);
 out:
@@ -278,11 +290,22 @@ int32_t audio_io_ios::StartRecordingInternal(void)
         }
         
         if (!is_playing_.load()) {
-		OSStatus result = AudioOutputUnitStart(au_);
-		if (result != noErr) {
-			error("audio_io_ios: AudioOutputUnitStart "
-			      "failed: %d \n", result);
-			return -1;
+		if (!is_au_started_.load()) {
+			dispatch_sync(dispatch_get_main_queue(), ^{
+				OSStatus result = -1;
+				if (nullptr != au_) {
+					result = AudioOutputUnitStart(au_);
+					if (result != noErr) {
+						error("audio_io_ios: AudioOutputUnitStart "
+						      "failed: %d \n", result);
+					}
+					else {
+						error("audio_io_ios: AudioOutputUnitStart in StartRecording\n",
+						      result);
+						is_au_started_.store(true);
+					}
+				}
+			});
 		}
         }
  out:
@@ -339,11 +362,14 @@ int32_t audio_io_ios::StopRecordingInternal(void)
 			dispatch_sync(dispatch_get_main_queue(), ^{
 				OSStatus result = -1;	
 				if (nullptr != au_) {
-					result = AudioOutputUnitStop(au_);
-					if (0 != result) {
-						error("audio_io_ios: "
-						      "AudioOutputUnitStop "
-						      "failed: %d ", result);
+					if (is_au_started_.load() && nullptr != au_) {
+						result = AudioOutputUnitStop(au_);
+						if (0 != result) {
+							error("audio_io_ios: "
+							      "AudioOutputUnitStop "
+							      "failed: %d ", result);
+						}
+						is_au_started_.store(false);
 					}
 				}
 			});
@@ -376,19 +402,18 @@ int32_t audio_io_ios::StopPlayoutInternal(void)
 
         if (!is_recording_.load()) {
 		// Both playout and recording has stopped, shutdown the device.
-		if (nullptr != au_) {
-			dispatch_sync(dispatch_get_main_queue(), ^{
-				OSStatus result = -1;
-				if (nullptr != au_) {
-					result = AudioOutputUnitStop(au_);
-					if (0 != result) {
-						error("audio_io_ios: "
-						      "AudioOutputUnitStop: %d\n",
-						      result);
-					}
+		dispatch_sync(dispatch_get_main_queue(), ^{
+			OSStatus result = -1;
+			if (is_au_started_.load() && nullptr != au_) {
+				result = AudioOutputUnitStop(au_);
+				if (0 != result) {
+					error("audio_io_ios: "
+					      "AudioOutputUnitStop: %d\n",
+					      result);
 				}
-			});
-		}
+				is_au_started_.store(false);
+			}
+		});
         }
 	
         is_playing_.store(false);

--- a/src/audio_io/ios/audio_io_ios.mm
+++ b/src/audio_io/ios/audio_io_ios.mm
@@ -362,7 +362,7 @@ int32_t audio_io_ios::StopRecordingInternal(void)
 			dispatch_sync(dispatch_get_main_queue(), ^{
 				OSStatus result = -1;	
 				if (nullptr != au_) {
-					if (is_au_started_.load() && nullptr != au_) {
+					if (is_au_started_.load()) {
 						result = AudioOutputUnitStop(au_);
 						if (0 != result) {
 							error("audio_io_ios: "

--- a/src/wcall/marshal.c
+++ b/src/wcall/marshal.c
@@ -260,6 +260,55 @@ out:
 	return md;
 }
 
+static char *mev_name(int id)
+{
+	switch(id) {
+	case WCALL_MEV_START:
+		return "START";
+	case WCALL_MEV_ANSWER:
+		return "ANSWER";
+	case WCALL_MEV_REJECT:
+		return "REJECT";
+	case WCALL_MEV_END:
+		return "END";
+	case WCALL_MEV_RESP:
+		return "RESP";
+	case WCALL_MEV_RECV_MSG:
+		return"RECV_MSG";
+	case WCALL_MEV_CONFIG_UPDATE:
+		return "CONFIG_UPDATE";
+	case WCALL_MEV_VIDEO_STATE_HANDLER:
+		return "CONFIG_UPDATE";		
+	case WCALL_MEV_VIDEO_SET_STATE:
+		return "VIDEO_SET_STATE";
+	case WCALL_MEV_MCAT_CHANGED:
+		return "MCAT_CHANGED";
+	case WCALL_MEV_AUDIO_ROUTE_CHANGED:
+		return "AUDIO_ROUTE_CHNAGED";
+	case WCALL_MEV_NETWORK_CHANGED:
+		return "NETWROK_CHNAGED";
+	case WCALL_MEV_INCOMING:
+		return "INCOMING";
+	case WCALL_MEV_SFT_RESP:
+		return "SFT_RESP";
+	case WCALL_MEV_SET_CLIENTS:
+		return "SET_CLIENTS";
+	case WCALL_MEV_DCE_SEND:
+		return "DCE_SEND";
+	case WCALL_MEV_DESTROY:
+		return "DESTROY";
+	case WCALL_MEV_SET_MUTE:
+		return "SET_MUTE";
+	case WCALL_MEV_REQ_VSTREAMS:
+		return "REQ_VSTREAMS";
+	case WCALL_MEV_SET_EPOCH_INFO:
+		return "SET_EPOCH_INFO";
+	case WCALL_MEV_PROCESS_NOTIFICATIONS:
+		return "PROCESS_NOTIFICATIONS";
+	default:
+		return "???";
+	}
+}
 
 static void mqueue_handler(int id, void *data, void *arg)
 {
@@ -466,7 +515,7 @@ static void mqueue_handler(int id, void *data, void *arg)
 
 out:
 	if (err)
-		warning("wcall: mqueue_handler error (%m)\n", err);
+		warning("wcall: mqueue_handler error (%m) handling event: %s\n", err, mev_name(id));
 
 	mem_deref(md);
 }

--- a/src/wcall/marshal.c
+++ b/src/wcall/marshal.c
@@ -514,8 +514,13 @@ static void mqueue_handler(int id, void *data, void *arg)
 	}
 
 out:
-	if (err)
-		warning("wcall: mqueue_handler error (%m) handling event: %s\n", err, mev_name(id));
+	if (err) {
+		char convid_anon[ANON_ID_LEN];
+
+		warning("wcall: mqueue_handler error (%m) handling event: %s convid=%s\n",
+			err, mev_name(id),
+			md->convid ? anon_id(convid_anon, md->convid) : "???");
+	}
 
 	mem_deref(md);
 }


### PR DESCRIPTION
This PR potentially fixes a crash when AudioUnitStop is called on a semi-started AU object, when main thread is slow to respond.