### PR TITLE
feat: Skip umbrella kmp in publishing in linux (WPB-24839)

### DIFF
--- a/kmp/build.gradle.kts
+++ b/kmp/build.gradle.kts
@@ -139,3 +139,16 @@ mavenPublishing {
         }
     }
 }
+
+val isLinux = System.getProperty("os.name").contains("Linux")
+
+// WPB-24839 CentralMaven require publication from a single place
+// Disable Umbrella kmp publication in linux jenkins host
+val avsKmp = "publishKotlinMultiplatformPublicationToMavenCentralRepository"
+tasks.withType<AbstractPublishToMaven>()
+    .matching { (it.name == avsKmp) }
+    .configureEach { 
+        if (isLinux) {
+           enabled = false
+        }
+    }


### PR DESCRIPTION
MavenCentral does not allow same publication sent from different sources. Disable umbrella kmp publication in linux jenkins.
