### PR TITLE
fix: iOS video capture incorrectly maps landscape orientation - WPB-24144

### DIFF
--- a/iosx/src/flowmgr/AVSCapturer.mm
+++ b/iosx/src/flowmgr/AVSCapturer.mm
@@ -595,11 +595,18 @@ out:
 				break;
 
 			case UIInterfaceOrientationLandscapeLeft:
-				newori = AVSDeviceOrientationLandscapeLeft;
+				// UIInterfaceOrientation landscape left means the device has been rotated
+				// (from portrait) right, whereas AVSDeviceOrientation (aka UIDeviceOrientation) 
+				// landscape left means the devices was rotated left. So we must flip and assign
+				// landscape right to have the same semantics.
+				// See https://developer.apple.com/documentation/uikit/uiinterfaceorientation/landscapeleft
+				// See https://developer.apple.com/documentation/uikit/uideviceorientation/landscapeleft
+				newori = AVSDeviceOrientationLandscapeRight;
 				break;
 
 			case UIInterfaceOrientationLandscapeRight:
-				newori = AVSDeviceOrientationLandscapeRight;
+				// if UI is right, assign device left. See previous case for explanation.
+				newori = AVSDeviceOrientationLandscapeLeft;
 				break;
 
 			default:


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
Given I am on a video call with an iPad in landscape orientation, when I tilt the iPad forward so that the screen is facing upwards, then at some point my self video is rotated 180 degrees and is upside down. When I tilt the iPad back to its upright position, the video flips again to the correct orientation. This is observed on both the sender and receiver side.


### Causes (Optional)
When the iPad is oriented horizontally the `UIDeviceOrientation` is `.landscapeLeft` (or right, but let's just pick left for this discussion). When the iPad is tilted forward at some point the orientation changes to `.faceUp`.

The `AVSCapturer` observes these changes to `UIDeviceOrientation` and uses it to update the orientation of the capture device. This orientation is mapped to `AVSDeviceOrientation`, which does not have cases for `.faceUp`, instead mapping it to `AVSDeviceOrientation.unknown`. If an `unknown` orientation is detected, the code falls back on the `UIInterfaceOrientation`, such that if interface orientation is `.landscapeLeft` then the `AVSDeviceOrientation.landscapeLeft` is used (and vice versa for `.landscapeRight`).

However, according to Apple docs, the semantics for [UIInterfaceOrientation.landscapeLeft](https://developer.apple.com/documentation/uikit/uiinterfaceorientation/landscapeleft) and [UIDeviceOrientation.landscapeLeft](https://developer.apple.com/documentation/uikit/uideviceorientation/landscapeleft)
are inverted. (The same applies for landscape right).

As a result, when falling back on the `UIInterfaceOrientation` and mapping it `UIDeviceOrientation` by name and not semantics, the capture device orientation is inverted.

### Solutions

Correct the mapping such that `UIInterfaceOrientation.landscapeLeft` maps to `UIDeviceOrientation.landscapeRight` (and vice versa for the opposite cases).

### Testing

#### How to Test

1. Start a video call on iPad in landscape mode.
2. Tilt the device to face up
3. Assert the video orientation doesn't flip vertically.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
