### PR TITLE
WPB-25354: Fix e2e tests

### DIFF
--- a/src/wcall/wcall.c
+++ b/src/wcall/wcall.c
@@ -1779,6 +1779,13 @@ static void icall_quality_handler(struct icall *icall,
 				stats.packets_per_sec.video.tx, stats.packets_per_sec.video.rx,
 				stats.packets_per_sec.lost.tx, stats.packets_per_sec.lost.rx);
 
+	// Do not remove following log line
+	// WPB-25354: e2e tests depend on parsing the line in order to evaluate flow
+	info("ar: %d vr: %d as: %d vs: %d",
+				stats.packets.audio.rx, stats.packets.video.rx,
+				stats.packets.audio.tx, stats.packets.audio.tx);
+
+
 	inst->quality.netqh(wcall->convid,
 			    userid,
 			    clientid,


### PR DESCRIPTION
Android e2e tests depend on parsing specific log line in order to evaluate media flow. Introduce this line back, till log parsing is refactored.

