### PR TITLE
feat: provide osx in xc framework (WPB-25608)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -148,13 +148,13 @@ pipeline {
                         sh 'make zcall AVS_VERSION=' + version
                         sh '''#!/bin/bash
                             . ./scripts/android_devenv.sh && echo "sdk.dir=${ANDROID_SDK_ROOT}\nndk.dir=${ANDROID_NDK_ROOT}" > local.properties
-                            . ./scripts/wasm_devenv.sh && make dist_osx dist_ios dist_wasm AVS_VERSION=''' + version + '  BUILDVERSION=' + version + '''
+                            . ./scripts/wasm_devenv.sh && make dist_xc dist_wasm AVS_VERSION=''' + version + '  BUILDVERSION=' + version + '''
                         '''
 
                         sh 'rm -rf ./build/artifacts'
                         sh 'mkdir -p ./build/artifacts'
                         sh 'cp ./build/dist/osx/avs.framework.zip ./build/artifacts/avs.framework.osx.' + version + '.zip'
-                        sh 'cp ./build/dist/ios/avs.xcframework.zip ./build/artifacts/avs.xcframework.zip'
+                        sh 'cp ./build/dist/xc/avs.xcframework.zip ./build/artifacts/avs.xcframework.zip'
                         sh 'zip -9j ./build/artifacts/zcall_osx_' + version + '.zip ./zcall'
                         sh 'mkdir -p ./osx'
                         sh 'cp ./build/dist/osx/avscore.tar.bz2 ./osx'

--- a/include/avs_wcall.h
+++ b/include/avs_wcall.h
@@ -105,7 +105,7 @@ typedef void (wcall_missed_h)(const char *convid, uint32_t msg_time,
 typedef void (wcall_network_quality_h)(const char *convid,
 				       const char *userid,
 				       const char *clientid,
-				       const char* quality_info,
+				       const char *quality_info,
 				       void *arg); 
 
 

--- a/mk/dist.mk
+++ b/mk/dist.mk
@@ -69,6 +69,7 @@ BUILD_DIST_AND := $(BUILD_DIST_BASE)/android
 BUILD_DIST_IOS := $(BUILD_DIST_BASE)/ios
 BUILD_DIST_IOSSIM := $(BUILD_DIST_BASE)/iossim
 BUILD_DIST_OSX := $(BUILD_DIST_BASE)/osx
+BUILD_DIST_XC := $(BUILD_DIST_BASE)/xc
 BUILD_DIST_LINUX := $(BUILD_DIST_BASE)/linux
 BUILD_DIST_WASM := $(BUILD_DIST_BASE)/wasm
 
@@ -330,10 +331,13 @@ dist_test: $(BUILD_DIST_IOS)/$(BUILD_LIB_REL)/$(BUILD_LIB_REL)
 $(BUILD_DIST_OSX)/$(BUILD_LIB_REL)/$(BUILD_LIB_REL):
 	@for arch in $(DIST_ARCH_osx) ; do \
 		$(MAKE) contrib AVS_OS=osx AVS_ARCH=$$arch && \
-		$(MAKE) iosx AVS_OS=osx AVS_ARCH=$$arch && \
-		mkdir -p $(dir $@) && \
-		cp $(BUILD_BASE)/osx-$$arch/lib/avs.framework/avs $@ ; \
+		$(MAKE) iosx AVS_OS=osx AVS_ARCH=$$arch ; \
 	done
+	@mkdir -p $(dir $@)
+
+	lipo -create -output $@ \
+		$(foreach arch,$(DIST_ARCH_osx),\
+		-arch $(arch) $(BUILD_BASE)/osx-$(arch)/lib/avs.framework/avs)
 
 
 # Package
@@ -354,13 +358,15 @@ $(BUILD_DIST_BASE)/%/$(BUILD_LIB_REL).framework.zip: \
 		zip --symlinks -r $@ Carthage )
 
 
-$(BUILD_DIST_IOS)/$(BUILD_LIB_REL).xcframework.zip:
+#--- xcframework ---
+$(BUILD_DIST_XC)/$(BUILD_LIB_REL).xcframework.zip:
+	@mkdir -p $(dir $@)
 	/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -create-xcframework \
-	$(foreach os,ios iossim,\
+	$(foreach os,ios iossim osx,\
                 -framework $(BUILD_DIST_BASE)/$(os)/Carthage/Build/iOS/avs.framework \
 		-debug-symbols $(BUILD_DIST_BASE)/$(os)/Carthage/Build/iOS/avs.framework.dSYM) \
-		-output $(BUILD_DIST_IOS)/avs.xcframework
-	@( cd $(BUILD_DIST_IOS) && \
+		-output $(BUILD_DIST_XC)/avs.xcframework
+	@( cd $(BUILD_DIST_XC) && \
 		zip --symlinks -r avs.xcframework.zip avs.xcframework )
 
 #--- iOSX Tarballs ---
@@ -463,8 +469,9 @@ $(DIST_WASM_TARGETS): $(DIST_WASM_JS_TARGET) $(DIST_WASM_PC_TARGET) $(DIST_WASM_
 
 .PHONY: dist_android dist_ios dist_osx dist_linux dist_wasm dist dist_host dist_clean
 dist_android: $(DIST_AND_TARGETS)
-dist_ios: $(DIST_IOS_TARGETS) $(DIST_IOSSIM_TARGETS) $(BUILD_DIST_IOS)/$(BUILD_LIB_REL).xcframework.zip
+dist_ios: $(DIST_IOS_TARGETS) $(DIST_IOSSIM_TARGETS)
 dist_osx: $(DIST_OSX_TARGETS)
+dist_xc: dist_ios dist_osx $(BUILD_DIST_XC)/$(BUILD_LIB_REL).xcframework.zip
 dist_linux: $(DIST_LINUX_TARGETS)
 dist_wasm: $(DIST_WASM_TARGETS)
 dist_clean:
@@ -474,6 +481,6 @@ ifeq ($(HOST_OS),linux)
 dist: dist_linux
 dist_host: dist_linux
 else
-dist: dist_android dist_ios dist_osx dist_wasm
+dist: dist_android dist_xc dist_wasm
 dist_host: dist_osx
 endif

--- a/mk/iosx.mk
+++ b/mk/iosx.mk
@@ -186,6 +186,7 @@ $(IOSX_FULL_SHARED): $(IOSX_LIB_OBJS) $(AVS_STATIC) $(MENG_STATIC)
 		-Xlinker -rpath -Xlinker @loader_path/Frameworks \
 		-Xlinker -no_implicit_dylibs \
 		-single_module \
+		-arch $(AVS_ARCH) \
 		$(SH_LFLAGS) $(LFLAGS) $(IOSX_LFLAGS) \
 		$^ $(SH_LIBS) $(LIBS) $(AVS_LIBS) $(MENG_LIBS) $(IOSX_LIBS) \
 		-o $(BUILD_LIB)/avs.framework/avs
@@ -194,6 +195,7 @@ $(IOSX_STUB_SHARED): $(IOSX_STUB_OBJS) $(AVS_STATIC) $(MENG_STATIC)
 	@echo "  LD      $@"
 	@mkdir -p $(dir $@)
 	$(LD)   $(SH_LFLAGS) $(LFLAGS) $(IOSX_LFLAGS) \
+		-arch $(AVS_ARCH) \
 		-ObjC \
 		$^ $(SH_LIBS) $(LIBS) $(AVS_LIBS) $(MENG_LIBS) $(IOSX_LIBS) \
 		-o $@


### PR DESCRIPTION
Fix osx build target architecture.

<img width="1910" height="362" alt="Screenshot from 2026-05-13 14-22-52" src="https://github.com/user-attachments/assets/f960dd61-8817-4850-aba9-7b8afd5ae56d" />

Moves xcframework from dst/ios to its own directory dist/xc
Add osx packages into xcframework.

<img width="2030" height="1265" alt="Screenshot from 2026-05-13 14-22-22" src="https://github.com/user-attachments/assets/a3fe66f0-491c-492a-956e-294209e1c256" />
