### PR TITLE
WPB-25801: Fix sanitizer warning in ecall destructor

### DIFF
--- a/src/ccall/ccall.c
+++ b/src/ccall/ccall.c
@@ -1077,8 +1077,6 @@ static void ecall_close_handler(struct icall *icall,
 	}
 
 	userlist_incall_clear(ccall->userl, false, false);
-	mem_deref(ecall);
-	ccall->ecall = NULL;
 
 	switch (ccall->error) {
 	case 0:
@@ -1127,6 +1125,9 @@ static void ecall_close_handler(struct icall *icall,
 				      msg_time, ccall->icall.arg);
 		}
 	}
+
+	mem_deref(ecall);
+	ccall->ecall = NULL;
 
 	ccall->error = 0;
 }


### PR DESCRIPTION
Fix sanitizer founding in ecall destructor

```
==745234==ERROR: AddressSanitizer: heap-use-after-free on address 0x5250000986a0 at pc 0x5ee63cd7da8d bp 0x7ffc7ae259a0 sp 0x7ffc7ae25998
READ of size 8 at 0x5250000986a0 thread T0
    #0 0x5ee63cd7da8c in ecall_close_handler /home/sifa.ozen/wire/wire-avs/src/ccall/ccall.c:1102:46
    #1 0x5ee63cdb1b1c in ecall_close /home/sifa.ozen/wire/wire-avs/src/ecall/ecall.c:161:3
    #2 0x5ee63cdb88c5 in econn_close_handler /home/sifa.ozen/wire/wire-avs/src/ecall/ecall.c:595:2
    #3 0x5ee63cdcae5e in econn_close /home/sifa.ozen/wire/wire-avs/src/econn/econn.c:78:3
    #4 0x5ee63cdcc29c in recv_hangup /home/sifa.ozen/wire/wire-avs/src/econn/econn.c:619:2
    #5 0x5ee63cdcb379 in econn_recv_message /home/sifa.ozen/wire/wire-avs/src/econn/econn.c:693:3
    #6 0x5ee63cdc84f5 in data_channel_handler /home/sifa.ozen/wire/wire-avs/src/ecall/ecall.c:1966:3
    #7 0x5ee63cd93518 in handle_mq(peerflow*, mq_data*, int) /home/sifa.ozen/wire/wire-avs/src/peerflow/peerflow.cpp:573:4
    #8 0x5ee63cd93518 in run_all_mq() /home/sifa.ozen/wire/wire-avs/src/peerflow/peerflow.cpp:680:4
    #9 0x5ee63cd93518 in mq_handler(int, void*, void*) /home/sifa.ozen/wire/wire-avs/src/peerflow/peerflow.cpp:693:2
    #10 0x5ee63ce31abb in event_handler /home/sifa.ozen/wire/wire-avs/contrib/re/src/mqueue/mqueue.c:86:2
```