### PR TITLE
fix: remote track identification for latest Chrome Canary [WPB-26006]

### DIFF
--- a/wasm/src/avs_pc.ts
+++ b/wasm/src/avs_pc.ts
@@ -747,7 +747,8 @@ function callStreamHandler(pc: PeerConnection,
       pc.rtc.getTransceivers().forEach(trans => {
         const track = trans.receiver.track;
         pc_log(LOG_LEVEL_INFO, `vsh: label:${track.label} id:${track.id} looking for: ${label}`);
-        if (trans.receiver.track.label === label) {
+
+        if (track.id === label) {
           if (uinfo) {
               uinfo.video_track_id = track.id;
           }
@@ -1486,11 +1487,7 @@ function pc_Create(hnd: number, privacy: number, conv_type: number) {
               pc_log(LOG_LEVEL_INFO, `onTrack: convid=${pc.convid.substring(0,8)} stream=${stream}`);
               for (const track of stream.getTracks()) {
                   if (track) {
-
-                      if (pc_env === ENV_FIREFOX)
-                          label = track.id;
-                      else
-                          label = track.label;
+                      label = track.id;
 
                       pc_log(LOG_LEVEL_INFO, `onTrack: convid=${pc.convid.substring(0,8)} track=${track.id}/${track.label}=>${label} kind=${track.kind} enabled=${track.enabled}/${track.muted}/undefined/${track.readyState} remote=undefined`);
                       if (!track.enabled)
@@ -1551,10 +1548,7 @@ function pc_Close(hnd: number) {
       const track = trans.receiver.track;
       if (track && track.kind === "audio") {
         let label: String = '';
-	if (pc_env == ENV_FIREFOX)
-	  label = track.id;
-	else
-          label = track.label;
+        label = track.id;
         if (audioStreamHandler && pc.rtc) {
           pc_log(LOG_LEVEL_INFO, `pc_Close: calling ash(${pc.convid.substring(0,8)}, ${label}) with 0 streams`);
           audioStreamHandler(pc.convid, hnd.toString() + label, null);


### PR DESCRIPTION
## Summery 
Chrome Canary no longer exposes SDP-derived values via ``transceiver.receiver.track.label``.
Our previous implementation relied on track.label for remote track identification, which is not spec-compliant and no longer stable in recent Chromium builds.

This change replaces:
```
transceiver.receiver.track.label
```
with:
```
transceiver.receiver.track.id
```
for remote track identification.

Background:
Recent Chromium/WebRTC changes align MediaStreamTrack.label with the WebRTC specification by assigning browser-generated labels (e.g. "remote video" / "remote audio") instead of propagating SDP labels.

As a result, remote video tracks were received and decoded correctly, but failed application-side track mapping, causing video playback to break in latest Chrome Canary builds.

https://issues.chromium.org/issues/40684245#comment12

This fix restores compatibility with current Chromium/WebRTC behavior.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
