### PR TITLE
fix: Fix devtools/ndk and gradle ndk version mismatch (WPB-26064)

### DIFF
--- a/kmp/build.gradle.kts
+++ b/kmp/build.gradle.kts
@@ -151,7 +151,7 @@ kotlin {
     }
 }
 
-// get devtools/ndk version
+// Get used devtools/ndk version, default to lask known working one if not found
 val systemNdkVersion = System.getenv("ANDROID_NDK_VER") ?: "28.2.13676358"
 
 android {

--- a/kmp/build.gradle.kts
+++ b/kmp/build.gradle.kts
@@ -151,6 +151,9 @@ kotlin {
     }
 }
 
+// get devtools/ndk version
+val systemNdkVersion = System.getenv("ANDROID_NDK_VER") ?: "28.2.13676358"
+
 android {
     namespace = "com.waz.avs"
     compileSdk = 34
@@ -158,6 +161,10 @@ android {
     defaultConfig {
         minSdk = 26
     }
+
+    // Set ndk version to resonate with devtoos/ndk version
+    // to avoid compatability errors in :avs-kmp:stripReleaseDebugSymbols
+    ndkVersion = systemNdkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION

Fix devtools/ndk and gradle ndk version mismatch