### PR TITLE
WPB-26635: Fix sftload tool variable destruction

### DIFF
--- a/tools/sftloader/sftloader.c
+++ b/tools/sftloader/sftloader.c
@@ -95,8 +95,6 @@ static void su_destructor(void *arg)
 	
 	wcall_destroy(su->wuser);
 
-	mem_deref(su->userid);
-	mem_deref(su->clientid);
 	mem_deref(su->dnsc);
 	mem_deref(su->httpc);
 

--- a/tools/sftloader/sftloader.c
+++ b/tools/sftloader/sftloader.c
@@ -36,8 +36,8 @@ struct sftloader {
 
 struct sft_user {
 	WUSER_HANDLE wuser;
-	char userid[ECONN_ID_LEN];
-	char clientid[ECONN_ID_LEN];
+	char *userid;
+	char *clientid;
 	char *convid;
 
 	struct dnsc *dnsc;
@@ -91,6 +91,8 @@ static void su_destructor(void *arg)
 	tmr_cancel(&su->tmr.duration);
 	tmr_cancel(&su->tmr.video);
 	
+	mem_deref(su->userid);
+	mem_deref(su->clientid);
 	mem_deref(su->convid);
 	
 	wcall_destroy(su->wuser);
@@ -739,7 +741,9 @@ static int create_user(uint32_t uidno, uint32_t cidno)
 	if (!su)
 		return ENOMEM;
 
+	su->userid = mem_zalloc(ECONN_ID_LEN, NULL);
 	snprintf(su->userid, ECONN_ID_LEN, "usr%05u", uidno);
+	su->clientid = mem_zalloc(ECONN_ID_LEN, NULL);
 	snprintf(su->clientid, ECONN_ID_LEN, "%04u", cidno);
 	str_dup(&su->convid, sftloader->convid);
 	su->ncalls = sftloader->ncalls;


### PR DESCRIPTION
Remove free for [statically allocated variables](https://github.com/wireapp/wire-avs/blob/5a8cfb6af422f95682e6a42d22ef5ab007813a18/tools/sftloader/sftloader.c#L39-L40)

<img width="1179" height="345" alt="image" src="https://github.com/user-attachments/assets/a3cc22c9-0ecb-4028-a460-35ca2cfc21dd" />


