### PR TITLE
WPB-26637: Fix ecall balance

### DIFF
--- a/src/ccall/ccall.c
+++ b/src/ccall/ccall.c
@@ -1107,6 +1107,9 @@ static void ecall_close_handler(struct icall *icall,
 		set_state(ccall, CCALL_STATE_IDLE);
 
 		if (ccall->error != EDURATION) {
+			// WPB-26637 Increase reference count of ecall to balance usage.
+			// Close handle will trigger wcalls destructor that dereference icall.
+			mem_ref(ecall);
 		        ICALL_CALL_CB(ccall->icall, closeh,
 				      &ccall->icall, ccall->error, &ccall->metrics, msg_time,
 				      NULL, NULL, ccall->icall.arg);


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

This pr aims to fix reference count on ecall obj.

we call wcall destructor indirectly here
https://github.com/wireapp/wire-avs/blob/5a8cfb6af422f95682e6a42d22ef5ab007813a18/src/ccall/ccall.c#L1111
which destructs ecall. then
it is dereferenced one more here
https://github.com/wireapp/wire-avs/blob/5a8cfb6af422f95682e6a42d22ef5ab007813a18/src/ccall/ccall.c#L1129