### PR TITLE
fix: handle null communication device in AudioRouter callback [WPB-26663]

### DIFF
--- a/android/lib/src/main/java/com/waz/media/manager/router/AudioRouter.java
+++ b/android/lib/src/main/java/com/waz/media/manager/router/AudioRouter.java
@@ -115,7 +115,7 @@ public class AudioRouter
 
 	    @Override
 	    public void onCommunicationDeviceChanged(AudioDeviceInfo device) {
-		    DoLog("onCommunicationDeviceChanged: dev=" + device.getType());
+		    DoLog("onCommunicationDeviceChanged: dev=" + (device == null ? "null" : device.getType()));
 		    this.router.UpdateRoute();
 	    }
     }


### PR DESCRIPTION
Fixes a crash in AVS `AudioRouter` when Android dispatches a communication-device change with a null type.

crash stacktrace 
```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'int android.media.AudioDeviceInfo.getType()' on a null object reference
  at com.waz.media.manager.router.AudioRouter$DeviceChangedListener.onCommunicationDeviceChanged (AudioRouter.java:118)
  at android.media.AudioManager$CommunicationDeviceDispatcherStub.lambda$dispatchCommunicationDeviceChanged$0 (AudioManager.java:9559)
  at android.media.AudioManager$CommunicationDeviceDispatcherStub$$ExternalSyntheticLambda0.callbackMethod (D8$$SyntheticClass)
  at android.media.CallbackUtil.lambda$callListeners$0 (CallbackUtil.java:222)
  at android.media.CallbackUtil$$ExternalSyntheticLambda0.run (D8$$SyntheticClass)
  at android.os.Handler.handleCallback (Handler.java:1070)
  at android.os.Handler.dispatchMessage (Handler.java:125)
  at android.os.Looper.dispatchMessage (Looper.java:358)
  at android.os.Looper.loopOnce (Looper.java:288)
  at android.os.Looper.loop (Looper.java:392)
  at android.app.ActivityThread.main (ActivityThread.java:10346)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:638)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:972)
```

## Cause
`AudioManager.OnCommunicationDeviceChangedListener.onCommunicationDeviceChanged()` can receive `null`, for example when the communication device is cleared during call teardown. `AudioRouter` was logging `device.getType()` unconditionally, causing an NPE

## Fix
Make the callback log `"null"` when no communication device is provided, while still calling `UpdateRoute()`.
