### PR TITLE
Feat/sifa/wpb 25538 add macos sanity test

### DIFF
--- a/test/kmp/README.md
+++ b/test/kmp/README.md
@@ -31,10 +31,25 @@ wire-avs$ ORG_GRADLE_PROJECT_VERSION_NAME=0.0.1 ./gradlew :avs:clean publishToMa
 ```
 
 * trigger kmp tests, that will run on the local published artifact  
+
+Linux
 ```bash
 wire-avs$ ./gradlew :test:kmp:clean :test:kmp:wasmJsBrowserTest
 ```
 
-* test results can be seen from generated html (file://**project-root-path**/wire-avs/test/kmp/build/reports/tests/wasmJsBrowserTest/index.html) 
+MacOS will have specific tests
+```bash
+wire-avs % ./gradlew :test:kmp:clean :test:kmp:wasmJsBrowserTest
+wire-avs % ./gradlew :test:kmp:clean :test:kmp:macosArm64Test
+```
 
+Running all available kmp tests
+```bash
+wire-avs % ./gradlew :test:kmp:clean :test:kmp:allTests
+```
+
+Note that google-chorome and firefox should be installed for wasm tests
+Be sure to install firefox throgh packet manager (rather han default snap)
+
+* test results can be seen from generated html (file://**project-root-path**/wire-avs/test/kmp/build/reports/tests/wasmJsBrowserTest/index.html) 
 ![test results](../../docs/assets/kmp-tests.png)

--- a/test/kmp/build.gradle.kts
+++ b/test/kmp/build.gradle.kts
@@ -1,14 +1,48 @@
+import org.gradle.internal.os.OperatingSystem
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
 }
 
+val isMacOs = OperatingSystem.current().isMacOsX
+
 kotlin {
     @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
     wasmJs {
-        browser {}
+        // by default empty browser {} block will use chrome headles
+        browser {
+            testTask {
+                useKarma {
+                    useChromeHeadless()
+                    // useFirefoxHeadless()
+                    if (isMacOs) {
+                        // safari does not have an headless mode
+                        useSafari()
+                    }
+                }
+            }
+        }
+    }
+
+    // Defines the macOS target (macosArm64 for Apple Silicon M1/M2/M3, macosX64 for Intel)
+    macosArm64 {
+        // we dont need the following block becouse kotlin generates it by default
+        // if we would like to configure, we can use
+        // getTest("DEBUG").apply { }
+        // binaries.test {
+            // Generates a native executable for tests
+        // }
     }
 
     sourceSets {
+        // Dependencies for all platform tests will be here when 'avs' is fully multiplatform
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test")) 
+            }
+        }
+
+
         // ... commonTest / commonMain / wasmJsMain definitions
         val wasmJsTest by getting {
             dependencies {
@@ -16,6 +50,15 @@ kotlin {
                 implementation(libs.coroutines.core)
                 implementation(libs.coroutines.test) 
                 implementation(libs.avs.local)
+            }
+        }
+
+        // macOS test target
+        val macosArm64Test by getting {
+            dependencies {
+                // Pulls in the library specifically for macOS testing execution
+                implementation(kotlin("test"))
+                implementation(libs.avs.local) 
             }
         }
     }

--- a/test/kmp/build.gradle.kts
+++ b/test/kmp/build.gradle.kts
@@ -14,10 +14,11 @@ kotlin {
             testTask {
                 useKarma {
                     useChromeHeadless()
-                    // useFirefoxHeadless()
+                    useFirefoxHeadless()
                     if (isMacOs) {
                         // safari does not have an headless mode
-                        useSafari()
+                        // an needs some modifications to be run
+                        // useSafari()
                     }
                 }
             }
@@ -38,27 +39,24 @@ kotlin {
         // Dependencies for all platform tests will be here when 'avs' is fully multiplatform
         val commonTest by getting {
             dependencies {
-                implementation(kotlin("test")) 
+                implementation(kotlin("test"))
+                implementation(libs.coroutines.core)
+                implementation(libs.coroutines.test)
+                implementation(libs.avs.local)
             }
         }
-
 
         // ... commonTest / commonMain / wasmJsMain definitions
         val wasmJsTest by getting {
             dependencies {
-                implementation(kotlin("test"))
-                implementation(libs.coroutines.core)
-                implementation(libs.coroutines.test) 
-                implementation(libs.avs.local)
+
             }
         }
 
         // macOS test target
         val macosArm64Test by getting {
             dependencies {
-                // Pulls in the library specifically for macOS testing execution
-                implementation(kotlin("test"))
-                implementation(libs.avs.local) 
+
             }
         }
     }

--- a/test/kmp/src/macosArm64Test/kotlin/com/example/SmokeTest.kt
+++ b/test/kmp/src/macosArm64Test/kotlin/com/example/SmokeTest.kt
@@ -1,4 +1,7 @@
-package com.wire.avskmp
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+import avs.wcall_init
+import avs.wcall_close
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -6,16 +9,13 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.cinterop.* // Essential for manual C-interop pointers if required
 
 class AvsMacosTests {
-    
+
     @Test
     fun testWcallInit() = runTest {
-        // Kotlin/Native maps C structures and pointers directly here
-        val wcallInstance: Wcall = getAvsInstance()
-        
         // Native C method handles parameters straight as Kotlin Primitive types
-        val err: Int = wcallInstance.init(0)
+        val err: Int = wcall_init(0)
         assertEquals(0, err, "Wcall init failure with error ${err}")
-        
-        wcallInstance.close()
+        wcall_close()
+
     }
 }

--- a/test/kmp/src/macosArm64Test/kotlin/com/example/SmokeTest.kt
+++ b/test/kmp/src/macosArm64Test/kotlin/com/example/SmokeTest.kt
@@ -1,0 +1,21 @@
+package com.wire.avskmp
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import kotlinx.cinterop.* // Essential for manual C-interop pointers if required
+
+class AvsMacosTests {
+    
+    @Test
+    fun testWcallInit() = runTest {
+        // Kotlin/Native maps C structures and pointers directly here
+        val wcallInstance: Wcall = getAvsInstance()
+        
+        // Native C method handles parameters straight as Kotlin Primitive types
+        val err: Int = wcallInstance.init(0)
+        assertEquals(0, err, "Wcall init failure with error ${err}")
+        
+        wcallInstance.close()
+    }
+}


### PR DESCRIPTION
Adds a smoke test for generated mac kmp package. Published packages can not be reverted, so it will be good to have a smoke test before publishing.
with this pr we will have smoke tests for

- wasm
- macos

android and ios simulator smoke tests will need supporting environments in jenkins/github.

ToDo: Run these in ci before publishing