### PR TITLE
WPB-27027: Fix ci sectest

### DIFF
--- a/src/ccall/ccall.c
+++ b/src/ccall/ccall.c
@@ -1109,7 +1109,9 @@ static void ecall_close_handler(struct icall *icall,
 		if (ccall->error != EDURATION) {
 			// WPB-26637 Increase reference count of ecall to balance usage.
 			// Close handle will trigger wcalls destructor that dereference icall.
-			mem_ref(ecall);
+			// mem_ref(ecall);
+			// WPB-27027 Revert this change as it makes sectest fail
+			// sectest wrapper does not have the same logic with wcall
 		        ICALL_CALL_CB(ccall->icall, closeh,
 				      &ccall->icall, ccall->error, &ccall->metrics, msg_time,
 				      NULL, NULL, ccall->icall.arg);


### PR DESCRIPTION
Ccall wrapper in sectest had different logic than wcall handling the call flow. Revert a recent refcount modification that makes sectest unhappy, blocking the ci release.

We need to return back to this issue, as there is a known reference imbalance (use after free) that can cause prod segfault.
