### PR TITLE
Bugfix WPB-27422

### DIFF
--- a/src/ecall/ecall.c
+++ b/src/ecall/ecall.c
@@ -2698,14 +2698,15 @@ int ecall_set_video_send_state(struct ecall *ecall, enum icall_vstate vstate)
 	if (!ecall)
 		return EINVAL;
 
-	info("ecall(%p): set_video_send_state %s->%s  econn %p update %d\n",
+	info("ecall(%p): set_video_send_state %s->%s  econn %p update %d glare %d\n",
 	     ecall,
 	     icall_vstate_name(ecall->vstate),
 	     icall_vstate_name(vstate),
 	     ecall->econn,
-	     ecall->update);
+	     ecall->update,
+	     ecall->update_glare);
 
-	if (ecall->vstate == vstate) {
+	if (ecall->vstate == vstate && !ecall->update_glare) {
 		info("ecall(%p): set_video_send_state: ignorig, already in state: %s\n",
 		     ecall, icall_vstate_name(ecall->vstate));
 


### PR DESCRIPTION
This PR fixes issue WPB-27422 where a user in a 1:1 call switches on their camera before the other user answers, and then switches it off still before the other user has answered, will cause the camera to remain on.