### PR TITLE
Link Apple AVS dynamically for AVS-KMP [WPB-27766]

### DIFF
--- a/kmp/build.gradle.kts
+++ b/kmp/build.gradle.kts
@@ -64,7 +64,6 @@ val osxLinkerOpts = listOf(
 fun generateIosOsxDef(
     buildDir: File,
     targetName: String,
-    staticLibraryDir: String,
     linkerOpts: String,
 ): File {
 
@@ -75,9 +74,7 @@ fun generateIosOsxDef(
             language = Objective-C
             modules = avs
             package = avs
-            staticLibraries = libavsobjc.stripped.a
-            libraryPaths = $staticLibraryDir
-            linkerOpts = $linkerOpts
+            linkerOpts = -framework avs $linkerOpts
             """.trimIndent()
         )
     }
@@ -89,32 +86,37 @@ kotlin {
     val generatedBuildDir = File(path, "build")
 
     val appleTargets = listOf(
-        Triple("iosArm64", "ios-arm64", "ios-arm64"),
-        Triple("iosSimulatorArm64", "ios-arm64_x86_64-simulator", "iossim-arm64"),
-        Triple("macosX64", "macos-arm64_x86_64", "osx-x86_64"),
-        Triple("macosArm64", "macos-arm64_x86_64", "osx-arm64")
+        Pair("iosArm64", "ios-arm64"),
+        Pair("iosSimulatorArm64", "ios-arm64_x86_64-simulator"),
+        Pair("macosArm64", "macos-arm64_x86_64")
     )
 
-    appleTargets.forEach { (targetName, xcDir, libDir) ->
+    appleTargets.forEach { (targetName, xcDir) ->
         val target = when (targetName) {
             "iosArm64" -> iosArm64()
             "iosSimulatorArm64" -> iosSimulatorArm64()
-            "macosX64" -> macosX64()
             "macosArm64" -> macosArm64()
             else -> error("Unknown target")
+        }
+
+        target.compilations.configureEach {
+            compileTaskProvider.configure {
+                compilerOptions.freeCompilerArgs.addAll(
+                    "-Xklib-relative-path-base=$path",
+                    "-Xklib-normalize-absolute-path",
+                )
+            }
         }
 
         target.compilations.getByName("main") {
             val avs by cinterops.creating() {
                 val frameworkPath = file("$path/build/dist/xc/avs.xcframework/$xcDir/").absolutePath
-                val staticLibraryDir = file("$path/build/$libDir/lib").absolutePath
                 val linkerOpts = if (targetName.startsWith("ios")) iosLinkerOpts else osxLinkerOpts
 
                 definitionFile.set(
                     generateIosOsxDef(
                         generatedBuildDir,
                         targetName,
-                        staticLibraryDir,
                         linkerOpts
                     )
                 )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

AVS-kmp crashes on apple targets when used on the same app with core-crypto


### Causes (Optional)

avs-kmp currently embeds the static libavsobjc.a, which includes WebRTC/BoringSSL symbols such as HMAC_Init_ex. CoreCrypto is also linked statically and includes its own incompatible OpenSSL implementation. Kotlin/Native puts both into the same executable, so some CoreCrypto calls resolve to AVS/BoringSSL functions and crash.

### Solutions

mimic what AVS bindings for Objective-C do, dynamically link the KMP bindings through avs.xcframework, this means the final app will need to do some stuff to include Kalium/AVS on kmp and swift projects, we accept this for a smaller releases onto Maven (no binaries for each platform is added) and easier to maintain on avs side

An alternative that was discussed is to prefix AVS/WebRTC BoringSSL symbols  which will keep the binaries statically linked and easier to consume by apps; however, it was discarded for now as it can add complexity. We may revisit it in the future. 

once merged i can cherry pick it to main and 10.5 branches